### PR TITLE
Redirect with position is undefined in tdao position views + rename increase lock time view, route to match delete

### DIFF
--- a/src/components/TDaoPositions/DeleteTDaoPosition.tsx
+++ b/src/components/TDaoPositions/DeleteTDaoPosition.tsx
@@ -1,4 +1,5 @@
-import { useParams } from 'react-router';
+import { useEffect } from "react"
+import { useParams, useHistory } from 'react-router'
 import waitFor from '../../slices/waitFor'
 import { TransactionType } from '../../slices/transactions'
 import CreateTransactionButton from '../library/CreateTransactionButton'
@@ -16,6 +17,7 @@ interface MatchParams {
 }
 
 const DeleteTDaoPosition = () => {
+  const history = useHistory()
   const params: MatchParams = useParams()
   const dispatch = useAppDispatch()
 
@@ -38,6 +40,19 @@ const DeleteTDaoPosition = () => {
 
   const position = tdaoPositions === null ? null : tdaoPositions[positionID]
 
+  useEffect(() => {
+    if(position === undefined) return
+    history.push('/positions')
+  }, [history, position])
+
+  if(position === undefined) {
+    return (
+      <div>
+        <LargeText>Position {params.positionID} is not owned by the current user.</LargeText>
+      </div>
+    )
+  }
+
   const columnOne =
     <>
       <div>
@@ -45,7 +60,7 @@ const DeleteTDaoPosition = () => {
           options={PositionUpdateOptions}
           initialValue={PositionUpdateOptions.Delete}
           navigation={{
-            [PositionUpdateOptions.IncreaseLockTime]: `/positions/${positionID}`
+            [PositionUpdateOptions.IncreaseLockTime]: `/positions/increase/${positionID}`
           }}
           width={300}
           label="TDao position update options"

--- a/src/components/TDaoPositions/IncreaseLockTimeTDaoPosition.tsx
+++ b/src/components/TDaoPositions/IncreaseLockTimeTDaoPosition.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react"
-import { useParams } from 'react-router';
+import { useEffect, useState } from "react"
+import { useParams, useHistory } from 'react-router';
 import waitFor from '../../slices/waitFor'
 import {
   Dropdown,
@@ -22,7 +22,8 @@ interface MatchParams {
   positionID: string
 }
 
-const TDaoPositionIncreaseLockTime = () => {
+const IncreaseLockTimeTDaoPosition = () => {
+  const history = useHistory()
   const params: MatchParams = useParams()
   const dispatch = useAppDispatch()
 
@@ -46,6 +47,19 @@ const TDaoPositionIncreaseLockTime = () => {
   const [ newDurationMonths, setNewDurationMonths ] = useState(48)
 
   const position = tdaoPositions === null ? null : tdaoPositions[positionID]
+
+  useEffect(() => {
+    if(position === undefined) return
+    history.push('/positions')
+  }, [history, position])
+
+  if(position === undefined) {
+    return (
+      <div>
+        <LargeText>Position {params.positionID} is not owned by the current user.</LargeText>
+      </div>
+    )
+  }
 
   let monthSelector = null
 
@@ -139,4 +153,4 @@ const TDaoPositionIncreaseLockTime = () => {
 
 }
 
-export default TDaoPositionIncreaseLockTime
+export default IncreaseLockTimeTDaoPosition

--- a/src/components/TDaoPositions/index.tsx
+++ b/src/components/TDaoPositions/index.tsx
@@ -1,5 +1,5 @@
 import { Switch, Route } from 'react-router-dom'
-import TDaoPositionIncreaseLockTime from './TDaoPositionIncreaseLockTime'
+import IncreaseLockTimeTDaoPosition from './IncreaseLockTimeTDaoPosition'
 import ExistingTDaoPositions from './ExistingTDaoPositions'
 import DeleteTDaoPosition from './DeleteTDaoPosition'
 import CreateTDaoAllocationPosition from './CreateTDaoAllocationPosition'
@@ -39,8 +39,8 @@ const Positions = () => (
     <Route path='/positions/delete/:positionID'>
       <DeleteTDaoPosition />
     </Route>
-    <Route path='/positions/:positionID'>
-      <TDaoPositionIncreaseLockTime />
+    <Route path='/positions/increase/:positionID'>
+      <IncreaseLockTimeTDaoPosition />
     </Route>
   </Switch>
 )


### PR DESCRIPTION
* Rename 'TDaoPositionIncreaseLockTime.tsx' -> 'IncreaseLockTimeTDaoPosition.tsx'
* Redirect to '/positions' if '/positions/delete/:positionID' is not owned by current user
* Change view route '/positions/:positionID' -> '/positions/increaseLockTime/:positionID'
* Redirect to '/positions' if '/positions/increaseLockTime/:positionID' is not owned by current user